### PR TITLE
Fix for multi-project builds

### DIFF
--- a/src/main/groovy/com/jimdo/gradle/AptPlugin.groovy
+++ b/src/main/groovy/com/jimdo/gradle/AptPlugin.groovy
@@ -113,7 +113,7 @@ class AptPlugin implements Plugin<Project> {
 
   def checkGradleAndroidPlugin(project) {
     // as in: http://stackoverflow.com/a/18119304/389262
-    def gradleAndroidPluginVersion = project.buildscript.configurations.classpath.resolvedConfiguration.firstLevelModuleDependencies.find { plugin ->
+    def gradleAndroidPluginVersion = project.rootProject.buildscript.configurations.classpath.resolvedConfiguration.firstLevelModuleDependencies.find { plugin ->
       plugin.moduleGroup == 'com.android.tools.build'
     }.moduleVersion
     if (!(gradleAndroidPluginVersion in GRADLE_ANDROID_PLUGIN_SUPPORTED_VERSIONS)) {


### PR DESCRIPTION
I have the android plugin defined in a top-level `build.gradle` rather than in the app subdirectory. This fixed the plugin to work again.
