### PR TITLE
Handle all JavaCompile tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ repositories {
 dependencies {
   compile gradleApi()
   compile "org.codehaus.groovy:groovy-all:1.8.6"
+  compile 'commons-lang:commons-lang:2.6'
 
   testCompile "org.spockframework:spock-core:0.6-groovy-1.8"
 }

--- a/src/main/groovy/com/jimdo/gradle/AptPlugin.groovy
+++ b/src/main/groovy/com/jimdo/gradle/AptPlugin.groovy
@@ -52,24 +52,20 @@ class AptPlugin implements Plugin<Project> {
 
       project.logger.info("Task $taskName has APT configuration $confName applied by task $confTaskName")
 
-      project.configurations.create(confName)
-      project.extensions.create(confName, AptPluginExtension, project.buildDir, confName)
-
-      project.afterEvaluate {
-        Configuration conf = project.configurations.getByName(confName)
-        String dir = project.extensions.getByName(confName).outputDirName
-        Task confTask = project.task(confTaskName)
-        confTask.dependsOn conf
-        confTask.doFirst {
-          compileTask.configure {
-            options.compilerArgs.addAll(['-processorpath', conf.asPath])
-            options.compilerArgs.addAll(['-s', dir])
-            source = source.filter { !it.path.startsWith(dir) }
-            doFirst { new File(dir).mkdirs() }
-          }
+      Configuration conf = project.configurations.create(confName)
+      AptPluginExtension extension = project.extensions.create(confName, AptPluginExtension, project.buildDir, confName)
+      Task confTask = project.task(confTaskName)
+      confTask.dependsOn conf
+      confTask.doFirst {
+        String dir = extension.outputDirName
+        compileTask.configure {
+          options.compilerArgs.addAll(['-processorpath', conf.asPath])
+          options.compilerArgs.addAll(['-s', dir])
+          source = source.filter { !it.path.startsWith(dir) }
+          doFirst { new File(dir).mkdirs() }
         }
-        compileTask.dependsOn confTask
       }
+      compileTask.dependsOn confTask
     }
   }
 

--- a/src/main/groovy/com/jimdo/gradle/AptPlugin.groovy
+++ b/src/main/groovy/com/jimdo/gradle/AptPlugin.groovy
@@ -1,48 +1,81 @@
 package com.jimdo.gradle
 
-import org.gradle.api.Project
+import org.apache.commons.lang.StringUtils
 import org.gradle.api.Plugin
-
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.tooling.BuildException
 
 class AptPlugin implements Plugin<Project> {
 
   @Override void apply(Project project) {
-    project.configurations.create 'apt'
-    project.extensions.create 'apt', AptPluginExtension
-
-    project.afterEvaluate {
-      if (isJavaProject(project)) {
-        applyToJavaProject(project)
-      } else if (isAndroidProject(project)) {
-        applyToAndroidProject(project)
-      } else  {
+    if (isJavaProject(project)) {
+      applyToJavaProject(project)
+    } else {
+      project.afterEvaluate {
+        if (isAndroidProject(project)) {
+          applyToAndroidProject(project)
+        } else {
           throw new BuildException('The project isn\'t a java or android project', null)
+        }
       }
     }
   }
 
-  def applyToJavaProject(project) {
-    File aptOutputDir = getAptOutputDir(project)
-    project.task('addAptCompilerArgs') << {
-      project.compileJava.options.compilerArgs.addAll '-processorpath',
-      project.configurations.apt.asPath, '-s', aptOutputDir.path
-
-      project.compileJava.source = project.compileJava.source.filter {
-        !it.path.startsWith(aptOutputDir.path)
-      }
-
-      project.compileJava.doFirst {
-        logger.info "Generating sources using the annotation processing tool:"
-        logger.info "  Output directory: ${aptOutputDir}"
-
-        aptOutputDir.mkdirs()
+  def applyToJavaProject(Project project) {
+    def tasks = []
+    project.tasks.each { Task t ->
+      if (t instanceof JavaCompile) {
+        tasks.add t
       }
     }
-    project.tasks.getByName('compileJava').dependsOn 'addAptCompilerArgs'
+    tasks.each { Task t ->
+      JavaCompile compileTask = (JavaCompile) t
+      String taskName = compileTask.name
+
+      String confName
+      def pattern = taskName =~ '^compile(.*)Java$'
+      if (pattern) {
+        String taskNamePart = pattern.group(1)
+        if (taskNamePart.isEmpty()) {
+          confName = 'apt'
+        } else {
+          confName = StringUtils.uncapitalize(taskNamePart) + 'Apt'
+        }
+      } else {
+        confName = taskName + 'Apt'
+      }
+
+      String confTaskName = 'configureAptFor' + StringUtils.capitalize(taskName)
+
+      project.logger.info("Task $taskName has APT configuration $confName applied by task $confTaskName")
+
+      project.configurations.create(confName)
+      project.extensions.create(confName, AptPluginExtension, project.buildDir, confName)
+
+      project.afterEvaluate {
+        Configuration conf = project.configurations.getByName(confName)
+        String dir = project.extensions.getByName(confName).outputDirName
+        Task confTask = project.task(confTaskName)
+        confTask.dependsOn conf
+        confTask.doFirst {
+          compileTask.configure {
+            options.compilerArgs.addAll(['-processorpath', conf.asPath])
+            options.compilerArgs.addAll(['-s', dir])
+            source = source.filter { !it.path.startsWith(dir) }
+            doFirst { new File(dir).mkdirs() }
+          }
+        }
+        compileTask.dependsOn confTask
+      }
+    }
   }
 
   def applyToAndroidProject(project) {
+    project.configurations.create 'apt'
+    project.extensions.create 'apt', AptPluginExtension
     def androidExtension
     def variants
 
@@ -99,11 +132,7 @@ class AptPlugin implements Plugin<Project> {
     variant.dirName.split('/').last()
   }
 
-  def getAptOutputDir(project) {
-    def aptOutputDirName = project.apt.outputDirName
-    if (!aptOutputDirName) {
-      aptOutputDirName = 'build/source/apt'
-    }
-    project.file aptOutputDirName
+  private static File getAptOutputDir(project) {
+    return project.file(project.apt.outputDirName)
   }
 }

--- a/src/main/groovy/com/jimdo/gradle/AptPluginExtension.groovy
+++ b/src/main/groovy/com/jimdo/gradle/AptPluginExtension.groovy
@@ -2,4 +2,7 @@ package com.jimdo.gradle
 
 class AptPluginExtension {
   String outputDirName
+  AptPluginExtension(File projectBuildDir, String confName) {
+    outputDirName = [projectBuildDir, 'generated-sources', confName].join(File.separator)
+  }
 }


### PR DESCRIPTION
This patch adds more sophisticated handling for Java projects, enabling one to use APT not only in 'compileJava' tasks, but all tasks of type 'JavaCompile'.

Important notes:
- The default generated source directory name has been changed, as has the mechanism of obtaining said default. The new version enables the project build script to read the default, not only override it.
- The default directory change affects both Java and Android projects. All the other changes are Java-exclusive, because I have absolutely no experience with Android. Hopefully, if similar functionality is needed, you (or another contributor) can add it easily based on my work.
- The plugin used to be applied fully inside a project.afterEvaluate invocation. From now on, this is not the case. The reason is that, if the plugin only works _after_ the project is evaluated, the user cannot access configurations and extensions generated by this plugin in the project's build script. To fix that, I moved the creation of configurations and extensions, which are now done at the time of plugin application.
- This pull-request breaks the tests. I can't fix them, because I can't even run them, because I have groovy 2.2.3 and spock wants 1.8 (or 2.0.5 with the latest release of spock, but it's still too low), and I can't make them become friends :(
