### PR TITLE
Test config for java project

### DIFF
--- a/src/main/groovy/com/jimdo/gradle/AptPluginExtension.groovy
+++ b/src/main/groovy/com/jimdo/gradle/AptPluginExtension.groovy
@@ -2,4 +2,5 @@ package com.jimdo.gradle
 
 class AptPluginExtension {
   String outputDirName
+  String testOutputDirName
 }


### PR DESCRIPTION
Modifies the plugin to work with Java test configs as well. 

Since it runs during compile time there shouldn't really be a reason to identify compile dependencies vs test dependencies. All the change does is generate additional code based on what is in the test source. 

Also base on a very little amount of testing configuring the target directory is possible.

Also to be honest I don't know what line 131 is for groovy isn't something I fully understand.